### PR TITLE
fix source of problem in which seeded example is not available

### DIFF
--- a/seed_database.py
+++ b/seed_database.py
@@ -1,0 +1,12 @@
+import shelve
+from input.read_document import Sample
+import pathlib, os
+document = 'util/12thGrade-informationExplanatory.txt'
+
+report = Sample(document)
+path = pathlib.Path(__file__).parent.absolute()
+db = shelve.open(os.path.join(path, 'shelve.db'))
+
+db['example'] = report
+
+db.close()


### PR DESCRIPTION
### Shelve Database: Resolving Strange Behavior

Shelve seeded example stopped showing up in the web interface after deployment script and release 1.

Fix:

* return app.py to how it was before
* change seed_database to save with certainty to the app path, rather than user's home directory.